### PR TITLE
SS-7782: map legacy color values to [0,1] range

### DIFF
--- a/libs/sdk.sdtf-primitives/__tests__/integration_tests/type_color.test.ts
+++ b/libs/sdk.sdtf-primitives/__tests__/integration_tests/type_color.test.ts
@@ -21,7 +21,7 @@ describe("type color", function () {
     test("read legacy and get content", async () => {
         const asset = await sdk.createParser().readFromFile("./test_data/color_legacy.sdtf")
         const content = await asset.items[0].getContent()
-        expect(content).toStrictEqual([ 126, 156, 255, 1 ])
+        expect(content).toStrictEqual([ 126 / 255, 156 / 255, 255 / 255, 1 ])
         SdtfPrimitiveTypeGuard.assertColor(content)
     })
 

--- a/libs/sdk.sdtf-primitives/__tests__/unit_tests/SdtfPrimitiveTypeReader.test.ts
+++ b/libs/sdk.sdtf-primitives/__tests__/unit_tests/SdtfPrimitiveTypeReader.test.ts
@@ -113,8 +113,8 @@ describe("mapColor", function () {
     })
 
     test("legacy color format", () => {
-        expect(reader.mapColor("1,1,1")).toStrictEqual([ 1, 1, 1, 1 ])
-        expect(reader.mapColor("1,1,1,0")).toStrictEqual([ 1, 1, 1, 0 ])
+        expect(reader.mapColor("255,255,255")).toStrictEqual([ 1, 1, 1, 1 ])
+        expect(reader.mapColor("255,255,255,0")).toStrictEqual([ 1, 1, 1, 0 ])
     })
 
 })

--- a/libs/sdk.sdtf-primitives/src/SdtfPrimitiveTypeReader.ts
+++ b/libs/sdk.sdtf-primitives/src/SdtfPrimitiveTypeReader.ts
@@ -61,8 +61,9 @@ export class SdtfPrimitiveTypeReader implements ISdtfTypeReader {
             // Handle regular color
             parts = content
         } else {
-            // Handle legacy color: Map sdTF color string to array
-            parts = (content as string).split(",").map(p => Number(p))
+            // Handle legacy color: Map sdTF color string to array and divide by 255
+            // Example: "255,255,255" -> [ 1, 1, 1 ]
+            parts = (content as string).split(",").map(p => Number(p) / 255)
         }
 
         let res = [ ...parts ]


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-7782

Pretty straightforward. With this change we now always receive color values in the [0,1] range.